### PR TITLE
Purpose a pin assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,18 @@ The footprints are available as a Kicad mod footprint file under downloads. I'll
 You do need to adjust your SOIC-8 test clip so that it will close enough to press the contact pins against the PCB pads. See the photos in the images folder - about 1mm will do to start with. Depending on your pin configuration, you need to make sure opposing contacts don't touch each other when no PCB is between them. 
 
 Also, you may need to use short sections of thin traces to escape the pads between the NPTH.
+
+# Pin assignment
+
+If you don't know where to start, here are a few suggestions for pin assignments of some interfaces:
+
+| Pin | UART | SPI       | SWIM | SWD   | ESP8266 |
+| --- | ---  | ---       | ---  | ---   | ---     |
+| 1   | RTS  | RST       | NRST |       | RST     |
+| 2   | RX2  | CS        |      |       | GPIO0   |
+| 3   | TX2  |           |      |       | GPIO2   |
+| 4   | GND  | GND       | GND  | GND   | GND     |
+| 5   | RX   | MOSI/MOMI | SWIM | SWDIO | RX      |
+| 6   | TX   | MISO      |      | SWO   | TX      |
+| 7   | CTS  | SCK/CLK   |      | SWCLK | CH_PD   |
+| 8   | Vcc  | Vcc       | Vcc  | Vcc   | Vcc     |

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ If you don't know where to start, here are a few suggestions for pin assignments
 
 | Pin | UART | SPI       | SWIM | SWD   | ESP8266 |
 | --- | ---  | ---       | ---  | ---   | ---     |
-| 1   | RTS  | RST       | NRST |       | RST     |
+| 1   | Vcc  | Vcc       | Vcc  | Vcc   | Vcc     |
 | 2   | RX2  | CS        |      |       | GPIO0   |
 | 3   | TX2  |           |      |       | GPIO2   |
 | 4   | GND  | GND       | GND  | GND   | GND     |
 | 5   | RX   | MOSI/MOMI | SWIM | SWDIO | RX      |
 | 6   | TX   | MISO      |      | SWO   | TX      |
 | 7   | CTS  | SCK/CLK   |      | SWCLK | CH_PD   |
-| 8   | Vcc  | Vcc       | Vcc  | Vcc   | Vcc     |
+| 8   | RTS  | RST       | NRST |       | RST     |


### PR DESCRIPTION
This is just a starting point to suggest a pin assignment for this
connector. It would be great if every project with a SOICbite connector
could be used similar, with the same programmer. Anyhow, a "version 1"
probably should be discussed somehow with all the pros and cons. This
one uses the SPI pinout of an AVR AT-Tiny and tries to assign similar
functions from other interfaces to the same pins.
UART TX2 and RX2 could be used as a 2nd (debug) interface in parallel to
e.g. SPI or SWIM.