### PR TITLE
Add JTAG pin specification to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Also, you may need to use short sections of thin traces to escape the pads betwe
 
 If you don't know where to start, here are a few suggestions for pin assignments of some interfaces:
 
-| Pin | UART | SPI       | SWIM | SWD   | ESP8266 | USB | I2C | PIC ICSP |
-| --- | ---  | ---       | ---  | ---   | ---     | --- | --- | ---      |
-| 1   | Vcc  | Vcc       | Vcc  | Vcc   | Vcc     | Vcc | Vcc | Vcc      |
-| 2   | RX2  | CS        |      |       | GPIO0   | D-  |     | Vpp      |
-| 3   | TX2  |           |      |       | GPIO2   | D+  |     |          |
-| 4   | GND  | GND       | GND  | GND   | GND     | GND | GND | GND      |
-| 5   | RX   | MOSI/MOMI | SWIM | SWDIO | RX      |     | SDA | DAT      |
-| 6   | TX   | MISO      |      | SWO   | TX      |     |     | AUX      |
-| 7   | CTS  | SCK/CLK   |      | SWCLK | CH_PD   |     | SCL | CLK      |
-| 8   | RTS  | RST       | NRST | NRST  | RST     | ID  |     |          |
+| Pin | UART | SPI       | SWIM | SWD   | ESP8266 | USB | I2C | PIC ICSP | JTAG |
+| --- | ---- | --------- | ---- | ----- | ----------- | --- | --- | -------- | ---- |
+| 1   | Vcc  | Vcc       | Vcc  | Vcc   | Vcc         | Vcc | Vcc | Vcc      | Vcc  |
+| 2   | RX2  | CS        |      |       | GPIO0       | D-  |     | Vpp      | TMS  |
+| 3   | TX2  |           |      |       | GPIO2       | D+  |     |          | TCK  |
+| 4   | GND  | GND       | GND  | GND   | GND         | GND | GND | GND      | GND  |
+| 5   | RX   | MOSI/MOMI | SWIM | SWDIO | RX          |     | SDA | DAT      | TDI  |
+| 6   | TX   | MISO      |      | SWO   | TX          |     |     | AUX      | TDO  |
+| 7   | CTS  | SCK/CLK   |      | SWCLK | CH_PD       |     | SCL | CLK      | RTCK |
+| 8   | RTS  | RST       | NRST | NRST  | RST         | ID  |     |          | NRST |


### PR DESCRIPTION
I'm designing an adapter and wanted a JTAG pinout for the SOICbite, and figured I might as well contribute it upstream. 

This PR just adds the JTAG column to the table, as below:

| Pin | UART | SPI       | SWIM | SWD   | ESP8266 | USB | I2C | PIC ICSP | JTAG |
| --- | ---- | --------- | ---- | ----- | ----------- | --- | --- | -------- | ---- |
| 1   | Vcc  | Vcc       | Vcc  | Vcc   | Vcc         | Vcc | Vcc | Vcc      | Vcc  |
| 2   | RX2  | CS        |      |       | GPIO0       | D-  |     | Vpp      | TMS  |
| 3   | TX2  |           |      |       | GPIO2       | D+  |     |          | TCK  |
| 4   | GND  | GND       | GND  | GND   | GND         | GND | GND | GND      | GND  |
| 5   | RX   | MOSI/MOMI | SWIM | SWDIO | RX          |     | SDA | DAT      | TDI  |
| 6   | TX   | MISO      |      | SWO   | TX          |     |     | AUX      | TDO  |
| 7   | CTS  | SCK/CLK   |      | SWCLK | CH_PD       |     | SCL | CLK      | RTCK |
| 8   | RTS  | RST       | NRST | NRST  | RST         | ID  |     |          | NRST |
